### PR TITLE
PLIN-2610: Update Module Path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
-module github.com/json-iterator/go
+module github.com/skuid/json-iterator-go
 
 go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/gofuzz v1.0.0
+	github.com/json-iterator/go v1.1.10
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=


### PR DESCRIPTION
When upgrading skuid-cli to use the Go module system the following error was encountered:

```shell
~/go/src/github.com/skuid/skuid-cli PLIN-2334-Upgrade-to-Go-1.14* ⇡
❯ go get
go: github.com/skuid/json-iterator-go@v1.1.7: parsing go.mod:
	module declares its path as: github.com/json-iterator/go
	        but was required as: github.com/skuid/json-iterator-go
```

The module declaration in our fork needs to be updated to github.com/skuid/json-iterator-go.